### PR TITLE
manager権限を持つメンバーの作成ロジックを追加

### DIFF
--- a/app/controllers/teams_controller.js
+++ b/app/controllers/teams_controller.js
@@ -15,6 +15,12 @@ class TeamsController extends Controller {
       ownerId: req.user.id
     });
     await team.save();
+    const member = models.Member.build({
+      teamId: team.id,
+      userId: req.user.id,
+      role: 1
+    });
+    await member.save();
     await req.flash('info', `新規チーム[${team.name}]を作成しました`);
     res.redirect(`/manager/teams/${team.id}`);
   }

--- a/app/middlewares/managable_team.js
+++ b/app/middlewares/managable_team.js
@@ -1,0 +1,9 @@
+module.exports = async function managableTeam(req, res, next) {
+  const members = await req.user.getMembers({ where : { teamId: req.params.team, role: 1 } });
+  if ( members.length > 0 ) {
+    return next();
+  } else {
+    await req.flash('alert', 'アクセスできません');
+    res.redirect('/');
+  }
+};

--- a/app/models/member.js
+++ b/app/models/member.js
@@ -22,7 +22,7 @@ module.exports = (sequelize, DataTypes) => {
       });
     }
   }
-  Member.roles = { normal: 0, admin: 1 };
+  Member.roles = { member: 0, manager: 1 };
   Member.init({
     teamId: {
       type: DataTypes.INTEGER,

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -12,8 +12,8 @@
 		},
 		"Member": {
 			"roles": {
-				"0": "Normal",
-				"1": "Admin"
+				"0": "Member",
+				"1": "Manager"
 			}
 		}
 	}

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 const { Route } = require('../lib/route');
 const forceLogin = require('../app/middlewares/force_login');
 const forceAdmin = require('../app/middlewares/force_admin');
+const managableTeam = require('../app/middlewares/managable_team');
 
 const route = new Route();
 
@@ -20,11 +21,11 @@ route.post('/teams', forceLogin, 'teams_controller@store');
 route.resource('examples', 'examples_controller');
 
 // /managerのURL階層の作成
-const managerRoute = route.sub('/manager', forceLogin);
-managerRoute.resource('teams', { controller: 'manager/teams_controller', only: ['show', 'edit', 'update'] });
+const managerRoute = route.sub('/manager');
+managerRoute.resource('teams', managableTeam, { controller: 'manager/teams_controller', only: ['show', 'edit', 'update'] });
 
 // /manager/teams/:teamのURL階層の作成
-const managerTeamRoute = route.sub('/manager/teams/:team');
+const managerTeamRoute = route.sub('/manager/teams/:team', managableTeam);
 managerTeamRoute.resource('tasks', { controller: 'manager/tasks_controller', only: ['create', 'store', 'edit', 'update'] });
 managerTeamRoute.resource('members', { controller: 'manager/members_controller', only: ['index', 'store'] });
 


### PR DESCRIPTION
- Team作成時(POST: /teams)に、Teamを作成したUserをmanager権限としMemberを作成する
- /manager/teams/:teamが含まれるURLパスへのアクセスを制限したい
上記の実装が完了いたしましたのでご確認のほどよろしくお願いいたします。