### PR TITLE
タスクへのコメント機能を実装

### DIFF
--- a/app/controllers/comments_controller.js
+++ b/app/controllers/comments_controller.js
@@ -6,20 +6,19 @@ class CommentsController extends Controller {
   async store(req, res) {
     const user = await this._user(req);
     const task = await this._task(req);
-    let kind = 0;
     if (req.body.finished) { 
-      kind = 1;
-      task.set({ status: 1 }); 
-      await task.save();
+      await task.finish(user, task, req.body.message);
+      await req.flash('info', '完了報告しました');
+    } else {
+      const comment = models.Comment.build({
+        taskId: task.id,
+        creatorId: user.id,
+        message: req.body.message,
+        kind: 0
+      });
+      await comment.save();
+      await req.flash('info', `${req.body.message}を送信しました`);
     }
-    const comment = models.Comment.build({
-      taskId: task.id,
-      creatorId: user.id,
-      message: req.body.message,
-      kind: kind
-    });
-    await comment.save();
-    await req.flash('info', `${req.body.message}を送信しました`);
     res.redirect(`/tasks/${task.id}`);
   }
 

--- a/app/controllers/comments_controller.js
+++ b/app/controllers/comments_controller.js
@@ -1,0 +1,38 @@
+const Controller = require('./controller');
+const models = require('../models');
+
+class CommentsController extends Controller {
+  // POST /
+  async store(req, res) {
+    const user = await this._user(req);
+    const task = await this._task(req);
+    const comment = models.Comment.build({
+      taskId: task.id,
+      creatorId: user.id,
+      message: req.body.message
+    });
+    await comment.save();
+    await req.flash('info', `${req.body.message}を送信しました`);
+    res.redirect(`/tasks/${task.id}`);
+  }
+
+
+  async _user(req) {
+    const user = await models.User.findByPk(req.user.id);
+    if (!user) {
+      throw new Error('User not find');
+    }
+    return user;
+  }
+
+  async _task(req) {
+    const task = await models.Task.findByPk(req.params.task);
+    if (!task) {
+      throw new Error('Task not find');
+    }
+    return task;
+  }
+
+}
+
+module.exports = CommentsController;

--- a/app/controllers/comments_controller.js
+++ b/app/controllers/comments_controller.js
@@ -6,6 +6,10 @@ class CommentsController extends Controller {
   async store(req, res) {
     const user = await this._user(req);
     const task = await this._task(req);
+    if (req.body.finished) { 
+      task.set({ status: 1 }); 
+      await task.save();
+    }
     const comment = models.Comment.build({
       taskId: task.id,
       creatorId: user.id,

--- a/app/controllers/comments_controller.js
+++ b/app/controllers/comments_controller.js
@@ -6,14 +6,17 @@ class CommentsController extends Controller {
   async store(req, res) {
     const user = await this._user(req);
     const task = await this._task(req);
+    let kind = 0;
     if (req.body.finished) { 
+      kind = 1;
       task.set({ status: 1 }); 
       await task.save();
     }
     const comment = models.Comment.build({
       taskId: task.id,
       creatorId: user.id,
-      message: req.body.message
+      message: req.body.message,
+      kind: kind
     });
     await comment.save();
     await req.flash('info', `${req.body.message}を送信しました`);

--- a/app/controllers/tasks_controller.js
+++ b/app/controllers/tasks_controller.js
@@ -8,6 +8,7 @@ class TasksController extends Controller {
     const task = await this._task(req);
     const team = await task.getTeam();
     const comments = await task.getComment({
+      include: ['creatorComment'],
       order: [['id', 'ASC']]
     });
     res.render('tasks/show', { task, team, comments });

--- a/app/controllers/tasks_controller.js
+++ b/app/controllers/tasks_controller.js
@@ -7,7 +7,10 @@ class TasksController extends Controller {
   async show(req, res) {
     const task = await this._task(req);
     const team = await task.getTeam();
-    res.render('tasks/show', { task, team });
+    const comments = await task.getComment({
+      order: [['id', 'ASC']]
+    });
+    res.render('tasks/show', { task, team, comments });
   }
 
   async _task(req) {

--- a/app/controllers/top_controller.js
+++ b/app/controllers/top_controller.js
@@ -4,6 +4,7 @@ const models = require('../models');
 class TopController extends Controller {
   // GET /
   async index(req, res) {
+    req.setLocale(req.query.lang || 'ja');
     const user = req.user;
     if (req.isAuthenticated()) {
       const members = await models.Member.findAll({

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -1,0 +1,35 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Comment extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+      this.TaskComment = this.belongsTo(models.Task, {
+        foreignKey: 'taskId',
+        as: 'taskComment'
+      });
+
+      this.CreatorComment = this.belongsTo(models.User, {
+        foreignKey: 'creatorId',
+        as: 'creatorComment'
+      });
+    }
+  }
+  Comment.init({
+    taskId: DataTypes.INTEGER,
+    creatorId: DataTypes.INTEGER,
+    message: DataTypes.TEXT,
+    kind: DataTypes.INTEGER
+  }, {
+    sequelize,
+    modelName: 'Comment',
+  });
+  return Comment;
+};

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -31,6 +31,18 @@ module.exports = (sequelize, DataTypes) => {
         as: 'comment'
       });
     }
+
+    async finish(user, task, message) {
+      task.set({ status: 1 });
+      await task.save();
+      await task.createComment({
+        taskId: task.id,
+        creatorId: user.id,
+        message: message,
+        kind: 1
+      });
+    }
+
   }
   Task.init({
     teamId: {

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -25,6 +25,11 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'assigneeId',
         as: 'assignee'
       });
+
+      this.Comment = this.hasMany(models.Comment, {
+        foreignKey: 'taskId',
+        as: 'comment'
+      });
     }
   }
   Task.init({

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -20,6 +20,11 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'userId',
         as: 'members'
       });
+
+      this.Comment = this.hasMany(models.Comment, {
+        foreignKey: 'creatorId',
+        as: 'comment'
+      });
     }
 
     static async signIn(params) {

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -1,7 +1,11 @@
 {
 	"AppTitle": "ExpressMVC",
 	"views": {
-		"Profile": "Profile"
+		"Profile": "Profile",
+		"Message": {
+			"AssignedTasks": "Assigned tasks",
+			"BelongTeam": "Team to belong"
+		}
 	},
 	"models": {
 		"User": {

--- a/config/locales/ja.json
+++ b/config/locales/ja.json
@@ -1,7 +1,11 @@
 {
 	"AppTitle": "ExpressMVC",
 	"views": {
-		"Profile": "プロフィール"
+		"Profile": "プロフィール",
+		"Message": {
+			"AssignedTasks": "アサインされているタスク",
+			"BelongTeam": "所属しているチーム"
+		}
 	},
 	"models": {
 		"User": {

--- a/database/migrations/20210524084250-create-comment.js
+++ b/database/migrations/20210524084250-create-comment.js
@@ -1,0 +1,38 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Comments', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      taskId: {
+        type: Sequelize.INTEGER,
+        references: { model: 'Tasks', key: 'id' }
+      },
+      creatorId: {
+        type: Sequelize.INTEGER,
+        references: { model: 'Users', key: 'id' }
+      },
+      message: {
+        type: Sequelize.TEXT
+      },
+      kind: {
+        type: Sequelize.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface, _Sequelize) => {
+    await queryInterface.dropTable('Comments');
+  }
+};

--- a/database/migrations/20210524115639-add-status-default-to-task.js
+++ b/database/migrations/20210524115639-add-status-default-to-task.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('Tasks', 'status', {
+      type: Sequelize.INTEGER,
+      defaultValue: 0
+    });
+
+
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('Tasks', 'status', {
+      type: Sequelize.INTEGER
+    });
+  }
+};

--- a/database/seeders/20210524084321-demo-comment.js
+++ b/database/seeders/20210524084321-demo-comment.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = {
+  up: async (_queryInterface, _Sequelize) => {
+    /**
+     * Add seed commands here.
+     *
+     * Example:
+     * await queryInterface.bulkInsert('People', [{
+     *   name: 'John Doe',
+     *   isBetaMember: false
+     * }], {});
+    */
+  },
+
+  down: async (_queryInterface, _Sequelize) => {
+    /**
+     * Add commands to revert seed here.
+     *
+     * Example:
+     * await queryInterface.bulkDelete('People', null, {});
+     */
+  }
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,13 +8,15 @@ const route = new Route();
 
 // single style
 route.get('/', 'top_controller@index');
-route.get('/tasks/:task', 'tasks_controller@show');
+route.get('/tasks/:task', forceLogin, 'tasks_controller@show');
 
 route.get('/user/edit', forceLogin, 'users_controller@edit');
 route.put('/user', forceLogin, 'users_controller@update');
 
 route.get('/teams/create', forceLogin, 'teams_controller@create');
 route.post('/teams', forceLogin, 'teams_controller@store');
+
+route.post('/tasks/:task/comments', forceLogin, 'comments_controller@store');
 
 // resource style
 route.resource('examples', 'examples_controller');

--- a/views/index.pug
+++ b/views/index.pug
@@ -3,7 +3,7 @@ extends layout
 block content
 
   if (user)
-    h2 アサインされているタスク
+    h2= __('views.Message.AssignedTasks')
     - var hasTasks = tasks.length > 0
     if hasTasks
       table(border=1)
@@ -27,7 +27,7 @@ block content
                 a(href=`/tasks/${task.id}`) 詳細
     else
       p タスクはありません
-    h2 所属しているチーム
+    h2= __('views.Message.BelongTeam')
     a(href="/teams/create") チーム作成
     - var hasTeams = members.length > 0
     if hasTeams

--- a/views/tasks/show.pug
+++ b/views/tasks/show.pug
@@ -10,8 +10,8 @@ block content
   h3 コメント
   ul
     each comment in comments
-      li= comment.message
-      li(type="none")= helpers.formatDateTime(comment.createdAt)
+      li #{comment.message}
+      li(type="none") #{helpers.formatDateTime(comment.createdAt)} #{comment.creatorComment.displayName}
 
   form(action=`/tasks/${task.id}/comments`, method="POST")
     _csrf

--- a/views/tasks/show.pug
+++ b/views/tasks/show.pug
@@ -6,3 +6,19 @@ block content
 
   h2 内容
   p #{task.body}
+
+  h3 コメント
+  ul
+    each comment in comments
+      li= comment.message
+      li(type="none")= helpers.formatDateTime(comment.createdAt)
+
+  form(action=`/tasks/${task.id}/comments`, method="POST")
+    _csrf
+    _method='post'
+
+    div
+      label(for='message') メッセージ
+      br
+      textarea#message(name="message", cols="50", rows="5")
+      button(type="submit") 送信

--- a/views/tasks/show.pug
+++ b/views/tasks/show.pug
@@ -21,4 +21,11 @@ block content
       label(for='message') メッセージ
       br
       textarea#message(name="message", cols="50", rows="5")
+    div.actions
+      if (task.status === 0)
+        label(for="finished") 完了報告
+        input(type="checkbox", name="finished")
+      else
+        p 既に完了済みです
+    div.actions
       button(type="submit") 送信


### PR DESCRIPTION
- ログインユーザーがタスクにコメントできるようにしたい
- 「完了報告」にチェックをした状態でメッセージを送信した場合、:taskのTaskの状態(status)を完了状態(値を1)にしたい
- 完了済みのタスク(statusが1のtask)の場合、完了報告のチェックボックスを非表示にし「既に完了済みです」というメッセージを表示する(statusが0の場合はチェックボックスが表示される)
- 「完了報告」メッセージが作成された場合、kindを1とする(通常のメッセージは0)
- /tasks/:task/commentsへのリクエスト時(完了報告メッセージの場合)、Taskのstatus変更とCommentの作成を一括で行うfinishメソッドをTaskモデルに実装しよう。

上記の実装が完了いたしました。ご確認のほどよろしくお願いいたします。